### PR TITLE
docs: readme path fix

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@
     granted to it by virtue of its status as an Intergovernmental Organization
     or submit itself to any jurisdiction.
 
-.. include:: ../../README.rst
+.. include:: ../README.rst
 
 Indices and tables
 ==================

--- a/{{ cookiecutter.project_shortname }}/docs/index.rst
+++ b/{{ cookiecutter.project_shortname }}/docs/index.rst
@@ -1,5 +1,5 @@
 {% include 'misc/header.rst' %}
-.. include:: ../../README.rst
+.. include:: ../README.rst
 
 Contents:
 =========


### PR DESCRIPTION
* Fixes relative path for `README.rst`. (addresses #9, closes #10)

Signed-off-by: Marco Neumann <marco@crepererum.net>