### PR TITLE
installation: fix missing comma in classifiers

### DIFF
--- a/{{ cookiecutter.project_shortname }}/setup.py
+++ b/{{ cookiecutter.project_shortname }}/setup.py
@@ -94,7 +94,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-        'Topic :: Software Development :: Libraries :: Python Modules'
+        'Topic :: Software Development :: Libraries :: Python Modules',
         "Programming Language :: Python :: 2",
         # 'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>