### PR TITLE
docs: development preview -> developer preview

### DIFF
--- a/{{ cookiecutter.project_shortname }}/README.rst
+++ b/{{ cookiecutter.project_shortname }}/README.rst
@@ -21,7 +21,7 @@
 
 {{ cookiecutter.description }}
 
-*This is an experimental development preview release.*
+*This is an experimental developer preview release.*
 
 * Free software: GPLv2 license
 * Documentation: https://{{ cookiecutter.project_shortname }}.readthedocs.org.

--- a/{{ cookiecutter.project_shortname }}/RELEASE-NOTES.rst
+++ b/{{ cookiecutter.project_shortname }}/RELEASE-NOTES.rst
@@ -9,7 +9,7 @@ About
 
 {{ cookiecutter.description }}
 
-*This is an experimental development preview release.*
+*This is an experimental developer preview release.*
 
 What's new
 ----------


### PR DESCRIPTION
* Uses more common "developer preview" phrase instead of "development
  preview" phrase in the README and RELEASE-NOTES documentation
  templates.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>