### PR TITLE
global: extension + i18n boiler plate

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name": "Invenio FunGenerator",
+    "project_name": "Invenio-FunGenerator",
     "project_shortname": "{{ cookiecutter.project_name | lower | replace(' ', '-') }}",
     "package_name": "{{ cookiecutter.project_shortname | replace('-', '_') }}",
     "github_repo": "inveniosoftware/{{ cookiecutter.project_shortname  }}",
@@ -9,5 +9,9 @@
     "year": "2015",
     "copyright_holder": "{{ cookiecutter.author_name }}",
     "copyright_by_intergovernmental": true,
-    "superproject": "Invenio"
+    "superproject": "Invenio",
+    "transifex_project": "{{ cookiecutter.project_shortname }}",
+    "extension_class": "{{ cookiecutter.project_name | replace('-', '') | replace(' ', '') }}",
+    "config_prefix": "{{ cookiecutter.project_name | replace('Invenio-', '') | replace('-', '_') | upper }}"
+
 }

--- a/{{ cookiecutter.project_shortname }}/.tx/config
+++ b/{{ cookiecutter.project_shortname }}/.tx/config
@@ -1,0 +1,27 @@
+{% include 'misc/header.py' %}
+
+# TODO: Transifex integration
+#
+# 1) Create message catalog:
+#    $ python setup.py extract_messages
+#    $ python setup.py init_catalog -l <lang>
+#    $ python setup.py compile_catalog
+# 2) Ensure project has been created on Transifex under the inveniosoftware
+#    organisation.
+# 3) Install the transifex-client
+#    $ pip install transifex-client
+# 4) Push source (.pot) and translations (.po) to Transifex
+#    $ tx push -s -t
+# 5) Pull translations for a single language from Transifex
+#    $ tx pull -l <lang>
+# 6) Pull translations for all languages from Transifex
+#    $ tx pull -a
+
+[main]
+host = https://www.transifex.com
+
+[{{ cookiecutter.transifex_project }}.messagespot]
+file_filter = {{ cookiecutter.package_name }}/translations/<lang>/LC_MESSAGES/messages.po
+source_file = {{ cookiecutter.package_name }}/translations/messages.pot
+source_lang = en
+type = PO

--- a/{{ cookiecutter.project_shortname }}/MANIFEST.in
+++ b/{{ cookiecutter.project_shortname }}/MANIFEST.in
@@ -10,3 +10,4 @@
 # Check manifest will not automatically add these two files:
 include .dockerignore
 include .editorconfig
+include .tx/config

--- a/{{ cookiecutter.project_shortname }}/examples/app.py
+++ b/{{ cookiecutter.project_shortname }}/examples/app.py
@@ -1,0 +1,26 @@
+{% include 'misc/header.py' %}
+
+"""Minimal Flask application example for development.
+
+Run example development server:
+
+.. code-block:: console
+
+   $ cd examples
+   $ python app.py
+"""
+
+from __future__ import absolute_import, print_function
+
+from flask import Flask
+from flask_babelex import Babel
+
+from {{ cookiecutter.package_name }} import {{ cookiecutter.extension_class }}
+
+# Create Flask application
+app = Flask(__name__)
+Babel(app)
+{{ cookiecutter.extension_class }}(app)
+
+if __name__ == "__main__":
+    app.run()

--- a/{{ cookiecutter.project_shortname }}/setup.py
+++ b/{{ cookiecutter.project_shortname }}/setup.py
@@ -14,7 +14,7 @@ tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
     'isort>=4.2.2',
-    'pep257>=0.6.0',
+    'pep257>=0.7.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
@@ -37,13 +37,13 @@ setup_requires = [
 ]
 
 install_requires = [
+    'Flask-BabelEx>=0.9.2',
 ]
 
 packages = find_packages()
 
 
 class PyTest(TestCommand):
-
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
@@ -63,8 +63,11 @@ class PyTest(TestCommand):
     def finalize_options(self):
         """Finalize pytest."""
         TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
+        if hasattr(self, '_test_args'):
+            self.test_suite = ''
+        else:
+            self.test_args = []
+            self.test_suite = True
 
     def run_tests(self):
         """Run tests."""

--- a/{{ cookiecutter.project_shortname }}/tests/conftest.py
+++ b/{{ cookiecutter.project_shortname }}/tests/conftest.py
@@ -5,3 +5,14 @@
 from __future__ import absolute_import, print_function
 
 import pytest
+from flask import Flask
+
+
+@pytest.fixture()
+def app():
+    """Flask application fixture."""
+    app = Flask('testapp')
+    app.config.update(
+        TESTING=True
+    )
+    return app

--- a/{{ cookiecutter.project_shortname }}/tests/test_{{cookiecutter.package_name}}.py
+++ b/{{ cookiecutter.project_shortname }}/tests/test_{{cookiecutter.package_name}}.py
@@ -1,9 +1,39 @@
 {% include 'misc/header.py' %}
 
+"""Module tests."""
+
 from __future__ import absolute_import, print_function
+
+from flask import Flask
+from flask_babelex import Babel
+
+from {{ cookiecutter.package_name }} import {{ cookiecutter.extension_class }}
 
 
 def test_version():
     """Test version import."""
     from {{ cookiecutter.package_name }} import __version__
     assert __version__
+
+
+def test_init():
+    """Test extension initialization."""
+    app = Flask('testapp')
+    ext = {{ cookiecutter.extension_class }}(app)
+    assert '{{ cookiecutter.project_shortname}}' in app.extensions
+
+    app = Flask('testapp')
+    ext = {{ cookiecutter.extension_class }}()
+    assert '{{ cookiecutter.project_shortname}}' not in app.extensions
+    ext.init_app(app)
+    assert '{{ cookiecutter.project_shortname}}' in app.extensions
+
+
+def test_view(app):
+    """Test view."""
+    Babel(app)
+    {{ cookiecutter.extension_class}}(app)
+    with app.test_client() as client:
+        res = client.get("/")
+        assert res.status_code == 200
+        assert 'Welcome to {{ cookiecutter.project_name}}' in str(res.data)

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/__init__.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/__init__.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, print_function
 
+from .ext import {{ cookiecutter.extension_class }}
 from .version import __version__
 
-__all__ = ('__version__', )
+__all__ = ('__version__', '{{ cookiecutter.extension_class }}')

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/ext.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/ext.py
@@ -1,0 +1,31 @@
+{% include 'misc/header.py' %}
+"""{{ cookiecutter.description }}"""
+
+from __future__ import absolute_import, print_function
+
+from flask_babelex import gettext as _
+
+from .views import blueprint
+
+
+class {{ cookiecutter.extension_class }}(object):
+    """{{ cookiecutter.project_name}} extension."""
+
+    def __init__(self, app=None):
+        """Extension initialization."""
+        _('A translation string')
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Flask application initialization."""
+        self.init_config(app)
+        app.register_blueprint(blueprint)
+        app.extensions['{{ cookiecutter.project_shortname}}'] = self
+
+    def init_config(self, app):
+        """Initialize configuration."""
+        app.config.setdefault(
+            "{{ cookiecutter.config_prefix}}_BASE_TEMPLATE",
+            app.config.get("BASE_TEMPLATE",
+                           "{{ cookiecutter.package_name}}/base.html"))

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/templates/{{ cookiecutter.package_name }}/base.html
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/templates/{{ cookiecutter.package_name }}/base.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    {% raw %}{%- block page_body %}{%- endblock page_body %}{% endraw %}
+  </body>
+</html>

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/templates/{{ cookiecutter.package_name }}/index.html
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/templates/{{ cookiecutter.package_name }}/index.html
@@ -1,0 +1,6 @@
+{{'{%- extends config.'}}{{cookiecutter.config_prefix}}{{'_BASE_TEMPLATE %}'}}
+{% raw %}
+{%- block page_body %}
+{{_('Welcome to %(module_name)s', module_name=module_name)}}
+{%- endblock %}
+{% endraw %}

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/views.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/views.py
@@ -1,0 +1,22 @@
+{% include 'misc/header.py' %}
+"""{{ cookiecutter.description }}"""
+
+from __future__ import absolute_import, print_function
+
+from flask import Blueprint, render_template
+from flask_babelex import gettext as _
+
+blueprint = Blueprint(
+    '{{ cookiecutter.package_name }}',
+    __name__,
+    template_folder='templates',
+    static_folder='static',
+)
+
+
+@blueprint.route("/")
+def index():
+    """Basic view."""
+    return render_template(
+        "{{ cookiecutter.package_name }}/index.html",
+        module_name=_('{{ cookiecutter.project_name }}'))


### PR DESCRIPTION
* Adds boilerplate code and tests for Flask extension.

* Adds blueprint with support for templates and static folders.

* Adds dependency on Flask-BabelEx for gettext support.

* Adds support for uploading message catalogs to Transifex.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>