### PR TITLE
cookiecutter: fixed cookiecutterproject_name in docs files

### DIFF
--- a/{{ cookiecutter.project_shortname }}/docs/Makefile
+++ b/{{ cookiecutter.project_shortname }}/docs/Makefile
@@ -87,9 +87,9 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/cookiecutterproject_name.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/{{ cookiecutter.project_name }}.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/cookiecutterproject_name.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/{{ cookiecutter.project_name }}.qhc"
 
 applehelp:
 	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
@@ -104,8 +104,8 @@ devhelp:
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/cookiecutterproject_name"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/cookiecutterproject_name"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/{{ cookiecutter.project_name }}"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/{{ cookiecutter.project_name }}"
 	@echo "# devhelp"
 
 epub:

--- a/{{ cookiecutter.project_shortname }}/docs/make.bat
+++ b/{{ cookiecutter.project_shortname }}/docs/make.bat
@@ -127,9 +127,9 @@ if "%1" == "qthelp" (
 	echo.
 	echo.Build finished; now you can run "qcollectiongenerator" with the ^
 .qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\cookiecutterproject_name.qhcp
+	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\{{ cookiecutter.project_name }}.qhcp
 	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\cookiecutterproject_name.ghc
+	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\{{ cookiecutter.project_name }}.ghc
 	goto end
 )
 


### PR DESCRIPTION
* Fixes docs/Makefile and docs/make.bat files to use the
  correct project_name from cookiecutter configuration.
  (Closes #34)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>