### PR TITLE
docs: fix string format

### DIFF
--- a/{{ cookiecutter.project_shortname }}/docs/conf.py
+++ b/{{ cookiecutter.project_shortname }}/docs/conf.py
@@ -10,7 +10,7 @@ from docutils.utils import get_source_line
 def _warn_node(self, msg, node):
     """Do not warn on external images."""
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        self._warnfunc(msg, '{0}:{1}'.format(get_source_line(node)))
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 


### PR DESCRIPTION
* Changes the string format invocation in
  {{cookiecutter-invenio-module/docs/conf.py.
  (closes #39)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>