### PR TITLE
translations: inclusion of .pot files to MANIFEST

### DIFF
--- a/{{ cookiecutter.project_shortname }}/.gitignore
+++ b/{{ cookiecutter.project_shortname }}/.gitignore
@@ -45,7 +45,6 @@ coverage.xml
 
 # Translations
 *.mo
-*.pot
 
 # Django stuff:
 *.log

--- a/{{ cookiecutter.project_shortname }}/MANIFEST.in
+++ b/{{ cookiecutter.project_shortname }}/MANIFEST.in
@@ -11,5 +11,4 @@
 include .dockerignore
 include .editorconfig
 include .tx/config
-recursive-include {{ cookiecutter.package_name }} *.po
-recursive-include {{ cookiecutter.package_name }} *.mo
+recursive-include {{ cookiecutter.package_name }} *.po *.pot *.mo


### PR DESCRIPTION
* Adds *.pot files to MANIFEST.in and removes them from .gitignore.
  (related to inveniosoftware/invenio-accounts#46)

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>