### PR TITLE
installation: translation comments extraction

### DIFF
--- a/{{ cookiecutter.project_shortname }}/setup.cfg
+++ b/{{ cookiecutter.project_shortname }}/setup.cfg
@@ -16,6 +16,7 @@ copyright_holder = {{ cookiecutter.copyright_holder }}
 msgid_bugs_address = {{ cookiecutter.author_email }}
 mapping-file = babel.ini
 output-file = {{ cookiecutter.package_name }}/translations/messages.pot
+add-comments = NOTE
 
 [init_catalog]
 input-file = {{ cookiecutter.package_name }}/translations/messages.pot

--- a/{{ cookiecutter.project_shortname }}/setup.py
+++ b/{{ cookiecutter.project_shortname }}/setup.py
@@ -23,7 +23,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        "Sphinx>=1.3",
+        'Sphinx>=1.3',
     ],
     'tests': tests_require,
 }


### PR DESCRIPTION
* Adds support for extracting notes to translators of a module.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>