### PR TITLE
cookiecutter: todo additions and entry point fix

### DIFF
--- a/{{ cookiecutter.project_shortname }}/setup.py
+++ b/{{ cookiecutter.project_shortname }}/setup.py
@@ -96,7 +96,25 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    entry_points={},
+    entry_points={
+        'invenio_base.apps': [
+            '{{ cookiecutter.package_name }} = {{ cookiecutter.package_name }}:{{ cookiecutter.extension_class }}',
+        ],
+        'invenio_i18n.translations': [
+            'messages = {{ cookiecutter.package_name }}',
+        ],
+        # TODO: Edit these entry points to fit your needs.
+        # 'invenio_access.actions': [],
+        # 'invenio_admin.actions': [],
+        # 'invenio_assets.bundles': [],
+        # 'invenio_base.api_apps': [],
+        # 'invenio_base.api_blueprints': [],
+        # 'invenio_base.blueprints': [],
+        # 'invenio_celery.tasks': [],
+        # 'invenio_db.models': [],
+        # 'invenio_pidstore.minters': [],
+        # 'invenio_records.jsonresolver': [],
+    },
     extras_require=extras_require,
     install_requires=install_requires,
     setup_requires=setup_requires,

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/ext.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/ext.py
@@ -13,6 +13,9 @@ class {{ cookiecutter.extension_class }}(object):
 
     def __init__(self, app=None):
         """Extension initialization."""
+        # TODO: This is an example of translation string with comment. Please
+        # remove it.
+        # NOTE: This is a note to a translator.
         _('A translation string')
         if app:
             self.init_app(app)

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/templates/{{ cookiecutter.package_name }}/index.html
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/templates/{{ cookiecutter.package_name }}/index.html
@@ -1,6 +1,7 @@
 {{'{%- extends config.'}}{{cookiecutter.config_prefix}}{{'_BASE_TEMPLATE %}'}}
 {% raw %}
 {%- block page_body %}
+TODO: Example template, please remove if you do not need it.
 {{_('Welcome to %(module_name)s', module_name=module_name)}}
 {%- endblock %}
 {% endraw %}

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/views.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/views.py
@@ -1,6 +1,9 @@
 {% include 'misc/header.py' %}
 """{{ cookiecutter.description }}"""
 
+# TODO: This is an example file. Remove it if you do not need it, including
+# the templates and static folders as well as the test case.
+
 from __future__ import absolute_import, print_function
 
 from flask import Blueprint, render_template


### PR DESCRIPTION
* Adds extra todo items after bootstrapping. (closes #35)

* Adds entry points groups to setup.py. (addresses #31)

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>