### PR TITLE
cookiecutter: pytest-runner integration

### DIFF
--- a/{{ cookiecutter.project_shortname }}/setup.cfg
+++ b/{{ cookiecutter.project_shortname }}/setup.cfg
@@ -1,5 +1,8 @@
 {% include 'misc/header.py' %}
 
+[aliases]
+test=pytest
+
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build

--- a/{{ cookiecutter.project_shortname }}/setup.py
+++ b/{{ cookiecutter.project_shortname }}/setup.py
@@ -34,6 +34,7 @@ for reqs in extras_require.values():
 
 setup_requires = [
     'Babel>=1.3',
+    'pytest-runner>=2.6.2',
 ]
 
 install_requires = [
@@ -42,39 +43,6 @@ install_requires = [
 
 packages = find_packages()
 
-
-class PyTest(TestCommand):
-    """PyTest Test."""
-
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        """Init pytest."""
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-        try:
-            from ConfigParser import ConfigParser
-        except ImportError:
-            from configparser import ConfigParser
-        config = ConfigParser()
-        config.read('pytest.ini')
-        self.pytest_args = config.get('pytest', 'addopts').split(' ')
-
-    def finalize_options(self):
-        """Finalize pytest."""
-        TestCommand.finalize_options(self)
-        if hasattr(self, '_test_args'):
-            self.test_suite = ''
-        else:
-            self.test_args = []
-            self.test_suite = True
-
-    def run_tests(self):
-        """Run tests."""
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 # Get the version string. Cannot be done with import!
 g = {}
@@ -135,5 +103,4 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Development Status :: 1 - Planning',
     ],
-    cmdclass={'test': PyTest},
 )


### PR DESCRIPTION
* BETTER Integrates pytest with setuptools by using pytest-runner.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>