### PR TITLE
docs: contribution guide updates

### DIFF
--- a/{{ cookiecutter.project_shortname }}/CONTRIBUTING.rst
+++ b/{{ cookiecutter.project_shortname }}/CONTRIBUTING.rst
@@ -53,7 +53,7 @@ If you are proposing a feature:
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `invenio` for local development.
+Ready to contribute? Here's how to set up `{{ cookiecutter.project_shortname }}` for local development.
 
 1. Fork the `invenio` repo on GitHub.
 2. Clone your fork locally:
@@ -95,7 +95,12 @@ Ready to contribute? Here's how to set up `invenio` for local development.
    .. code-block:: console
 
       $ git add .
-      $ git commit -s -m "Your detailed description of your changes."
+      $ git commit -s 
+          -m "component: title without verbs" 
+          -m "* NEW Adds your new feature."
+          -m "* FIX Fixes an existing issue."
+          -m "* BETTER Improves and existing feature."
+          -m "* Changes something that should not be visible in release notes"
       $ git push origin name-of-your-bugfix-or-feature
 
 7. Submit a pull request through the GitHub website.
@@ -109,5 +114,5 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
 3. The pull request should work for Python 2.7, 3.3, 3.4 and 3.5. Check
-   https://travis-ci.com/{{ cookiecutter.github_repo }}/pull_requests
+   https://travis-ci.org/{{ cookiecutter.github_repo }}/pull_requests
    and make sure that the tests pass for all supported Python versions.


### PR DESCRIPTION
* FIX Removes a reference to Invenio and replaces it with a template
  variable. (closes #26)

* FIX Replaces a link to travis-ci.com with a link to travis-ci.org.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>