### PR TITLE
global: addition of licence headers for templates

### DIFF
--- a/{{ cookiecutter.project_shortname }}/misc/header.jinja2
+++ b/{{ cookiecutter.project_shortname }}/misc/header.jinja2
@@ -1,0 +1,25 @@
+{%- raw %}{#{% endraw %}
+# This file is part of {{ cookiecutter.superproject }}.
+# Copyright (C) {{ cookiecutter.year }} {{ cookiecutter.copyright_holder }}.
+#
+# {{ cookiecutter.superproject }} is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# {{ cookiecutter.superproject }} is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with {{ cookiecutter.superproject }}; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+{%- if cookiecutter.copyright_by_intergovernmental | lower not in ['0', 'f', 'false', 'n', 'no'] %}
+#
+# In applying this license, {{ cookiecutter.copyright_holder }} does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+{%- endif %}
+{% raw %}#}{% endraw -%}

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/templates/{{ cookiecutter.package_name }}/base.html
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/templates/{{ cookiecutter.package_name }}/base.html
@@ -1,3 +1,4 @@
+{%- include 'misc/header.jinja2' %}
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/templates/{{ cookiecutter.package_name }}/index.html
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/templates/{{ cookiecutter.package_name }}/index.html
@@ -1,3 +1,5 @@
+{% include 'misc/header.jinja2' %}
+
 {{'{%- extends config.'}}{{cookiecutter.config_prefix}}{{'_BASE_TEMPLATE %}'}}
 {% raw %}
 {%- block page_body %}


### PR DESCRIPTION
* FIX Adds missing licence headers for templates.  (closes #30)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>