### PR TITLE
docs: typo in author name fix

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,4 +21,4 @@ Contributors
 - Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Samuele Kaplun <Samuele.Kaplun@cern.ch>
 - Tibor Simko <tibor.simko@cern.ch>
-- Ivan Masar <helix84@centrum.sk>
+- Ivan Masár <helix84@centrum.sk>


### PR DESCRIPTION
@helix84 FYI we use `kwalitee check authors` that expect git commit authors to be in AUTHORS.rst. Maybe we can relax the condition on diacritic ... cc @tiborsimko 