### PR TITLE
cookiecutter: .gitignore update

### DIFF
--- a/{{ cookiecutter.project_shortname }}/.gitignore
+++ b/{{ cookiecutter.project_shortname }}/.gitignore
@@ -48,6 +48,7 @@ coverage.xml
 
 # Translations
 *.mo
+*.pot
 
 # Django stuff:
 *.log


### PR DESCRIPTION
* Adds .pot to .gitignore file.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>