### PR TITLE
tests: use tox for matrix and docker for env

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,6 +12,7 @@
     "superproject": "Invenio",
     "transifex_project": "{{ cookiecutter.project_shortname }}",
     "extension_class": "{{ cookiecutter.project_name | replace('-', '') | replace(' ', '') }}",
-    "config_prefix": "{{ cookiecutter.project_name | replace('Invenio-', '') | replace('-', '_') | upper }}"
-
+    "config_prefix": "{{ cookiecutter.project_name | replace('Invenio-', '') | replace('-', '_') | upper }}",
+    "python_versions": "py27,py35",
+    "databases": "mysql,postgres,sqlite"
 }

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 chmod a+x run-tests.sh
 
@@ -9,4 +9,21 @@ echo "Skeleton generated."
 echo "Please fix the following TODOs before you use the generated files:"
 grep --color=always --recursive --context=3 --line-number TODO .
 
-rm -r misc/ 
+rm -r misc/
+
+
+# Create the docker templates
+
+
+python_versions='{{cookiecutter.python_versions}}'
+python_versions=(${python_versions//,/ })
+for version in "${python_versions[@]}"; do
+    full_version="python${version: -1}${version: -2:1}"
+    cat > "tests/Dockerfile.${version}" <<EOD
+FROM ${full_version}
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /code
+RUN pip install --upgrade tox
+WORKDIR /code
+EOD
+done

--- a/{{ cookiecutter.project_shortname }}/docker-compose.test.yaml
+++ b/{{ cookiecutter.project_shortname }}/docker-compose.test.yaml
@@ -1,0 +1,58 @@
+{% include 'misc/header.py' %}
+
+version: '2'
+
+services:
+{%- if 'mysql' in cookiecutter.databases %}
+  mysql:
+    image: mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=dbpass123
+      - MYSQL_PASSWORD=dbpass123
+      - MYSQL_USER=workflows
+      - MYSQL_DATABASE=workflows
+
+{%- endif %}
+{%- if 'postgres' in cookiecutter.databases %}
+  postgres:
+    image: postgres
+    environment:
+      - POSTGRES_PASSWORD=dbpass123
+      - POSTGRES_USER=workflows
+      - PGDATA=/var/lib/postgresql/data/pgdata
+
+{%- endif %}
+
+  test-{{cookiecutter.python_versions.split(',')[0]}}:
+    build:
+      context: .
+      dockerfile: tests/Dockerfile.{{cookiecutter.python_versions.split(',')[0]}}:
+    command: tox -r
+    working_dir: /code
+    volumes:
+      - .:/code
+    environment:
+      - TOXENV=pep8,docs,doctests,docstyle,packaging,{{cookiecutter.python_versions.split(',')[0]}}:
+
+{%- for python in cookiecutter.python_versions.split(',') %}
+  {%- for database in cookiecutter.databases.split(',') %}
+    {%- if database == 'sqlite' and loop.index0 != 0 %}
+  test-{{python}}:
+    extends: test-{{cookiecutter.python_versions.split(',')[0]}}
+    build:
+      context: .
+      dockerfile: tests/Dockerfile.{{python}}
+    environment:
+      - TOXENV={{python}}
+
+    {%- else %}
+  test-{{python}}{{database}}:
+    extends: test-{{python}}
+    depends_on:
+      - {{database}}
+    environment:
+      - TOXENV={{python}}{{database}}
+
+    {%- endif %}
+  {%- endfor %}
+{%- endfor %}

--- a/{{ cookiecutter.project_shortname }}/pytest.ini
+++ b/{{ cookiecutter.project_shortname }}/pytest.ini
@@ -1,3 +1,0 @@
-{% include 'misc/header.py' %}
-[pytest]
-addopts = --pep8 --ignore=docs --cov={{ cookiecutter.package_name }} --cov-report=term-missing

--- a/{{ cookiecutter.project_shortname }}/tox.ini
+++ b/{{ cookiecutter.project_shortname }}/tox.ini
@@ -1,0 +1,90 @@
+{% include 'misc/header.py' %}
+[tox]
+envlist =
+    pep8, docstyle, docs, doctests, packaging,
+{%- for python in cookiecutter.python_versions.split(',') %}
+    {%- for database in cookiecutter.databases.split(',') %}
+        {%- if database == 'sqlite' %}
+    {{python}}
+        {%- else %}
+    {{python}}{{database}}
+        {%- endif %}
+    {%- endfor %}
+{%- endfor %}
+skip_missing_interpreters = true
+
+[testenv]
+setenv =
+    # This is required in order to get UTF-8 output inside of the subprocesses
+    # that our tests use.
+    LC_CTYPE = en_US.UTF-8
+{%- for python in cookiecutter.python_versions.split(',') %}
+    {%- for database in cookiecutter.databases.split(',') %}
+        {%- if database == 'sqlite' %}
+    {{python}}: SQLALCHEMY_DATABASE_URI={env:SQLALCHEMY_DATABASE_URI:sqlite:///test.db}
+        {%- elif database == 'mysql' %}
+    {{python}}mysql: SQLALCHEMY_DATABASE_URI={env:SQLALCHEMY_DATABASE_URI:mysql+pymysql://localhost/workflows}
+        {%- elif database == 'postgres' %}
+    {{python}}postgres: SQLALCHEMY_DATABASE_URI={env:SQLALCHEMY_DATABASE_URI:postgresql+psycopg2://localhost/workflows}
+        {%- endif %}
+    {%- endfor %}
+{%- endfor %}
+
+commands =
+    find {toxinidir} -type f -name "*.pyc" -delete
+    py.test \
+        --pep8 \
+        --cov={envsitepackagesdir}/{{ cookiecutter.package_name }} \
+        --cov-report=term-missing \
+        tests \
+        []
+
+deps =
+    -r{toxinidir}/test-requirements.txt
+{%- for python in cookiecutter.python_versions.split(',') %}
+    {%- for database in cookiecutter.databases.split(',') %}
+        {%- if database == 'mysql' %}
+    {{python}}mysql: pymysql
+        {%- elif database == 'postgres' %}
+    {{python}}postgres: psycopg2
+        {%- endif %}
+    {%- endfor %}
+{%- endfor %}
+    {docs,docstyle,doctests}: Sphinx==1.4.1
+
+basepython =
+    {pep8,docstyle,docs,doctests,packaging}: python2.7
+{%- for python in cookiecutter.python_versions.split(',') %}
+    {%- for database in cookiecutter.databases.split(',') %}
+        {%- if database == 'sqlite' %}
+    {{python}}: python{{ python[2] ~ '.' ~ python[3] }}
+        {%- else %}
+    {{python}}{{database}}: python{{ python[2] ~ '.' ~ python[3] }}
+        {%- endif %}
+    {%- endfor %}
+{%- endfor %}
+
+passenv =
+    SQLALCHEMY*
+
+whitelist_externals = find
+
+[flake8]
+exclude = .tox,*.egg,build,_vendor,data,docs
+select = E,W,F
+
+[testenv:docstyle]
+commands = pydocstyle {{ cookiecutter.package_name }}
+
+[testenv:docs]
+commands = sphinx-build -qnNW docs docs/_build/html
+
+[testenv:doctests]
+commands = sphinx-build -qnNW -b doctest docs docs/_build/doctest
+
+[testenv:packaging]
+commands = check-manifest --ignore ".travis-*"
+
+[testenv:pep8]
+deps = flake8
+commands = flake8 .


### PR DESCRIPTION
- Use tox to span the virtualenv matrix instead of directly travis, so
  the developer can run the tests locally.
- Use docker-compose to setup the testing environment, including the
  database, to achieve a really good and easy reproducibility without
  having to setup the databases and different python versions
  locally.

Signed-off-by: David Caro david@dcaro.es
