### PR TITLE
docs: addition of autodoc configuration

### DIFF
--- a/{{ cookiecutter.project_shortname }}/docs/conf.py
+++ b/{{ cookiecutter.project_shortname }}/docs/conf.py
@@ -307,3 +307,6 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
+
+# Autodoc configuraton.
+autoclass_content = 'both'


### PR DESCRIPTION
* Sets the autodoc configuration to insert into the main body of an
  autoclass directive the documentation from the `__init__` method and
  class documentation.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>