### PR TITLE
tests: addition of test_example_app.py

### DIFF
--- a/{{ cookiecutter.project_shortname }}/examples/app.py
+++ b/{{ cookiecutter.project_shortname }}/examples/app.py
@@ -7,7 +7,9 @@ Run example development server:
 .. code-block:: console
 
    $ cd examples
-   $ flask -a app.py --debug run
+   $ export FLASK_APP=app.py
+   $ export FLASK_DEBUG=1
+   $ flask run
 """
 
 from __future__ import absolute_import, print_function

--- a/{{ cookiecutter.project_shortname }}/tests/test_example_app.py
+++ b/{{ cookiecutter.project_shortname }}/tests/test_example_app.py
@@ -1,0 +1,27 @@
+{% include 'misc/header.py' %}
+
+"""Test example app."""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+
+def setup_module(module):
+    """Set up before all tests."""
+    # switch to examples/app.py
+    exampleappdir = os.path.join(os.path.split(sys.path[0])[0],
+                                 'examples')
+    os.chdir(exampleappdir)
+
+
+def teardown_module(module):
+    """Tear down after all tests."""
+    pass
+
+
+def test_example_app():
+    """Test example app."""
+    pass


### PR DESCRIPTION
This PR adds `test_example_app.py` to the package skeleton so that developers don't forget to write tests for example apps.

The current status of Invenio 3 package ecosystem as of 2016-08-31:

- the packages that have some example app tests:
  - invenio-marc21
  - invenio-records

- the packages that don't have any test for example app:
  - domapping
  - invenio-access
  - invenio-accounts
  - invenio-admin
  - invenio-base
  - invenio-circulation
  - invenio-classifier
  - invenio-collections
  - invenio-communities
  - invenio-csl-rest
  - invenio-db/example/app.py
  - invenio-deposit
  - invenio-documents
  - invenio-files-rest
  - invenio-formatter
  - invenio-github
  - invenio-groups
  - invenio-i18n
  - invenio-indexer
  - invenio-jsonschemas
  - invenio-logging
  - invenio-memento
  - invenio-metrics
  - invenio-oaiharvester
  - invenio-oaiserver
  - invenio-oauth2server
  - invenio-oauthclient
  - invenio-openaire
  - invenio-opendefinition
  - invenio-orcid
  - invenio-pages
  - invenio-pidstore
  - invenio-previewer
  - invenio-records-files
  - invenio-records-rest
  - invenio-records-ui
  - invenio-rest
  - invenio-search
  - invenio-search-ui
  - invenio-sipstore
  - invenio-theme
  - invenio-upgrader
  - invenio-userprofiles
  - invenio-webhooks

Issues to add `test_example_app.py` created for all of them.