### PR TITLE
RFC cookiecutter: fast_finish for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Cookiecutter - Invenio Module Template
-# Copyright (C) 2015 CERN
+# Copyright (C) 2015, 2016 CERN
 #
 # Cookiecutter - Invenio Module Template is free software; you can
 # redistribute it and/or modify it under the terms of the GNU General Public
@@ -28,6 +28,9 @@ notifications:
   email: false
 
 language: python
+
+matrix:
+  fast_finish: true
 
 cache:
   - pip

--- a/{{ cookiecutter.project_shortname }}/.travis.yml
+++ b/{{ cookiecutter.project_shortname }}/.travis.yml
@@ -7,6 +7,9 @@ sudo: false
 
 language: python
 
+matrix:
+  fast_finish: true
+
 cache:
   - pip
 


### PR DESCRIPTION
* Adds `fast_finish` option to Travis CI templates so that Travis CI
  builds would end as soon as one job fails. Helps to gain time.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>