### PR TITLE
travis: update tested Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ cache:
 
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
 
 before_install:

--- a/{{ cookiecutter.project_shortname }}/setup.py
+++ b/{{ cookiecutter.project_shortname }}/setup.py
@@ -96,8 +96,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Development Status :: 1 - Planning',
     ],


### PR DESCRIPTION
 * BETTER Removes a redundant Python versions for Travis.

Signed-off-by: PaulinaLach paulina.malgorzata.lach@cern.ch