### PR TITLE
travis: update nodejs to v6 LTS

### DIFF
--- a/{{ cookiecutter.project_shortname }}/.travis.yml
+++ b/{{ cookiecutter.project_shortname }}/.travis.yml
@@ -22,6 +22,7 @@ python:
   - "3.5"
 
 before_install:
+  - "nvm install 6; nvm use 6"
   - "travis_retry pip install --upgrade pip setuptools py"
   - "travis_retry pip install twine wheel coveralls requirements-builder"
   - "requirements-builder -e all --level=min setup.py > .travis-lowest-requirements.txt"


### PR DESCRIPTION
travis' default nodejs is v0.10.36 which missing the ``isAbsolute`` attribute causing the ``clean-css`` to fail. 

Also the minimum requirement for ``clean-css`` is [v4](https://github.com/jakubpawlowicz/clean-css)

The best for us is to test on the latest LTS version which is for now ``v6.x``

```
Now using node v0.10.36 (npm v1.4.28)
➜ node
> require('path')
{ resolve: [Function],
  normalize: [Function],
  join: [Function],
  relative: [Function],
  sep: '/',
  delimiter: ':',
  dirname: [Function],
  basename: [Function],
  extname: [Function],
  exists: [Function: deprecated],
  existsSync: [Function: deprecated],
  _makeLong: [Function] }
```

```
Now using node v6.9.5 (npm v3.10.10)
➜ node
> require('path')
{ resolve: [Function: resolve],
  normalize: [Function: normalize],
  isAbsolute: [Function: isAbsolute],
  join: [Function: join],
  relative: [Function: relative],
  _makeLong: [Function: _makeLong],
  dirname: [Function: dirname],
  basename: [Function: basename],
  extname: [Function: extname],
  format: [Function: format],
  parse: [Function: parse],
  sep: '/',
  delimiter: ':',
  win32:
   { resolve: [Function: resolve],
     normalize: [Function: normalize],
     isAbsolute: [Function: isAbsolute],
     join: [Function: join],
     relative: [Function: relative],
     _makeLong: [Function: _makeLong],
     dirname: [Function: dirname],
     basename: [Function: basename],
     extname: [Function: extname],
     format: [Function: format],
     parse: [Function: parse],
     sep: '\\',
     delimiter: ';',
     win32: [Circular],
     posix: [Circular] },
  posix: [Circular] }
>
```