### PR TITLE
tests: doctext execution simplification

### DIFF
--- a/{{ cookiecutter.project_shortname }}/docs/conf.py
+++ b/{{ cookiecutter.project_shortname }}/docs/conf.py
@@ -57,7 +57,9 @@ author = u'{{ cookiecutter.author_name }}'
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join('..', '{{ cookiecutter.package_name }}', 'version.py'), 'rt') as fp:
+with open(os.path.join(os.path.dirname(__file__), '..',
+                       '{{ cookiecutter.package_name }}', 'version.py'),
+          'rt') as fp:
     exec(fp.read(), g)
     version = g['__version__']
 

--- a/{{ cookiecutter.project_shortname }}/pytest.ini
+++ b/{{ cookiecutter.project_shortname }}/pytest.ini
@@ -1,3 +1,4 @@
 {% include 'misc/header.py' %}
 [pytest]
-addopts = --pep8 --ignore=docs --cov={{ cookiecutter.package_name }} --cov-report=term-missing
+pep8ignore = docs/conf.py ALL
+addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov={{ cookiecutter.package_name }} --cov-report=term-missing docs tests {{ cookiecutter.package_name }}

--- a/{{ cookiecutter.project_shortname }}/run-tests.sh
+++ b/{{ cookiecutter.project_shortname }}/run-tests.sh
@@ -4,5 +4,4 @@ pydocstyle {{ cookiecutter.package_name }} tests docs && \
 isort -rc -c -df && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test && \
-sphinx-build -qnNW -b doctest docs docs/_build/doctest
+python setup.py test


### PR DESCRIPTION
* Performs doctest execution within the initial pytest run, simplifying test
  suite execution and solving "disappearing development requirements" problem
  that was sometimes observed with development-level dependencies. (closes #97)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>