### PR TITLE
config: use of variables from config.py in ext.py

### DIFF
--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/config.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/config.py
@@ -6,3 +6,6 @@
 
 {{ cookiecutter.config_prefix}}_DEFAULT_VALUE = 'foobar'
 """Default value for the application."""
+
+{{ cookiecutter.config_prefix}}_BASE_TEMPLATE = '{{ cookiecutter.package_name}}/base.html'
+"""Default base template for the demo page."""

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/ext.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/ext.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, print_function
 
 from flask_babelex import gettext as _
 
+from . import config
 from .views import blueprint
 
 
@@ -28,7 +29,12 @@ class {{ cookiecutter.extension_class }}(object):
 
     def init_config(self, app):
         """Initialize configuration."""
-        app.config.setdefault(
-            "{{ cookiecutter.config_prefix}}_BASE_TEMPLATE",
-            app.config.get("BASE_TEMPLATE",
-                           "{{ cookiecutter.package_name}}/base.html"))
+        # Use theme's base template if theme is installed
+        if 'BASE_TEMPLATE' in app.config:
+            app.config.setdefault(
+                '{{ cookiecutter.config_prefix}}_BASE_TEMPLATE',
+                app.config['BASE_TEMPLATE'],
+            )
+        for k in dir(config):
+            if k.startswith('{{ cookiecutter.config_prefix}}_'):
+                app.config.setdefault(k, getattr(config, k))


### PR DESCRIPTION
* Updates ext.py so it uses variables from config.py

Signed-off-by: Rémi Ducceschi <remi.ducceschi@gmail.com>

This represents the new way of using config variables in modules. You can see examples here:
- https://github.com/inveniosoftware/invenio-access/blob/master/invenio_access/ext.py#L149
- https://github.com/inveniosoftware/invenio-accounts/blob/master/invenio_accounts/ext.py#L190

If you're OK with it, it may be useful that this PR gets merged before the IUGW2017.