### PR TITLE
tests: update sleep time

### DIFF
--- a/{{ cookiecutter.project_shortname }}/tests/test_examples_app.py
+++ b/{{ cookiecutter.project_shortname }}/tests/test_examples_app.py
@@ -30,7 +30,7 @@ def example_app():
     webapp = subprocess.Popen(
         'FLASK_APP=app.py flask run --debugger -p 5000',
         stdout=subprocess.PIPE, preexec_fn=os.setsid, shell=True)
-    time.sleep(3)
+    time.sleep(10)
     yield webapp
 
     # Stop server


### PR DESCRIPTION
- When used with vagrant, it is not enough to sleep 3 seconds.
  At least 7 seconds are needed, otherwise the test won't pass

EITHER you merge this one, or https://github.com/inveniosoftware/invenio/pull/3784