### PR TITLE
tests: pydocstyle 2.0.0 imperative mood fix

### DIFF
--- a/{{ cookiecutter.project_shortname }}/setup.cfg
+++ b/{{ cookiecutter.project_shortname }}/setup.cfg
@@ -10,6 +10,9 @@ all_files = 1
 [bdist_wheel]
 universal = 1
 
+[pydocstyle]
+add_ignore = D401
+
 [compile_catalog]
 directory = {{ cookiecutter.package_name }}/translations/
 


### PR DESCRIPTION
* Ignores pydocstyle error code D401 ("First line should be in
  imperative mood") as the parsing and detection is pretty broken.
  (addresses inveniosoftware/troubleshooting#9)

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>