### PR TITLE
license: use URI in place of snail mail

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,7 @@
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with Invenio; if not, see <http://www.gnu.org/licenses>.
 #
 # In applying this license, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 ..
     This file is part of Invenio.
-    Copyright (C) 2015 CERN.
+    Copyright (C) 2015, 2017 CERN.
 
     Invenio is free software; you can redistribute it and/or
     modify it under the terms of the GNU General Public License as
@@ -13,8 +13,7 @@
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Invenio; if not, write to the Free Software Foundation,
-    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+    along with Invenio; if not, see `<http://www.gnu.org/licenses>`_.
 
     In applying this license, CERN does not waive the privileges and immunities
     granted to it by virtue of its status as an Intergovernmental Organization
@@ -26,4 +25,3 @@ Indices and tables
 ==================
 
 * :ref:`search`
-

--- a/scripts/repocheck.py
+++ b/scripts/repocheck.py
@@ -13,10 +13,9 @@
 # warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with Cookiecutter - Invenio Module Template; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307, USA.
+# You should have received a copy of the GNU General Public License along with
+# Cookiecutter - Invenio Module Template; if not, see
+# <http://www.gnu.org/licenses>.
 #
 # In applying this license, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization

--- a/{{ cookiecutter.project_shortname }}/docs/license.rst
+++ b/{{ cookiecutter.project_shortname }}/docs/license.rst
@@ -11,8 +11,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Invenio; if not, write to the Free Software Foundation, Inc.,
-59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+along with Invenio; if not, see `<http://www.gnu.org/licenses>`_.
 
 In applying this license, CERN does not waive the privileges and immunities
 granted to it by virtue of its status as an Intergovernmental Organization or

--- a/{{ cookiecutter.project_shortname }}/misc/header.jinja2
+++ b/{{ cookiecutter.project_shortname }}/misc/header.jinja2
@@ -13,9 +13,7 @@
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with {{ cookiecutter.superproject }}; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-# MA 02111-1307, USA.
+# along with {{ cookiecutter.superproject }}; if not, see see <http://www.gnu.org/licenses>.
 {%- if cookiecutter.copyright_by_intergovernmental | lower not in ['0', 'f', 'false', 'n', 'no'] %}
 #
 # In applying this license, {{ cookiecutter.copyright_holder }} does not

--- a/{{ cookiecutter.project_shortname }}/misc/header.py
+++ b/{{ cookiecutter.project_shortname }}/misc/header.py
@@ -14,9 +14,7 @@
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with {{ cookiecutter.superproject }}; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-# MA 02111-1307, USA.
+# along with {{ cookiecutter.superproject }}; if not, see <http://www.gnu.org/licenses>.
 {%- if cookiecutter.copyright_by_intergovernmental | lower not in ['0', 'f', 'false', 'n', 'no'] %}
 #
 # In applying this license, {{ cookiecutter.copyright_holder }} does not

--- a/{{ cookiecutter.project_shortname }}/misc/header.rst
+++ b/{{ cookiecutter.project_shortname }}/misc/header.rst
@@ -13,9 +13,7 @@
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with {{ cookiecutter.superproject }}; if not, write to the
-    Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-    MA 02111-1307, USA.
+    along with {{ cookiecutter.superproject }}; if not, see `<http://www.gnu.org/licenses>`_.
 {%- if cookiecutter.copyright_by_intergovernmental | lower not in ['0', 'f', 'false', 'n', 'no'] %}
 
     In applying this license, {{ cookiecutter.copyright_holder }} does not


### PR DESCRIPTION
* Uses URI instead of snail-mail address in copyright/license headers.
  (closes #108)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>