### PR TITLE
editorconfig: Allow from ... import ( ... ) syntax

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ charset = utf-8
 indent_size = 4
 # isort plugin configuration
 known_first_party = invenio
-multi_line_output = 2
+multi_line_output = 5
 default_section = THIRDPARTY
 
 # RST files (used by sphinx)

--- a/{{ cookiecutter.project_shortname }}/.editorconfig
+++ b/{{ cookiecutter.project_shortname }}/.editorconfig
@@ -13,7 +13,7 @@ charset = utf-8
 indent_size = 4
 # isort plugin configuration
 known_first_party = {{ cookiecutter.package_name }}
-multi_line_output = 2
+multi_line_output = 5
 default_section = THIRDPARTY
 skip = .eggs
 


### PR DESCRIPTION
Arguments in favour of this are:

- Solution to the pep8 and isort "import too long" problem:

```python
from invenio_records_permissions.permissions.records import \
    record_create_permission_factory, record_delete_permission_factory, \
    record_read_permission_factory, record_update_permission_factory
```

fails isort. isort wants:

```python
from invenio_records_permissions.permissions.records import record_create_permission_factory, \
    record_delete_permission_factory, record_read_permission_factory, \
    record_update_permission_factory
```

which fails pep8!

```python
from invenio_records_permissions.permissions.records import (
    record_create_permission_factory, record_delete_permission_factory,
    record_read_permission_factory, record_update_permission_factory
)
```

works nicely with pep8 and isort with this change.

- Potentially less characters to type:

```python
from foo import (
    long_bar1_that_takes_up_the_line,
    long_bar2_that_takes_up_the_line,
    long_bar3_that_takes_up_the_line,
    long_bar4_that_takes_up_the_line,
)
```

is less characters than

```python
from foo import long_bar1_that_takes_up_the_line, \
    long_bar2_that_takes_up_the_line, \
    long_bar3_that_takes_up_the_line, \
    long_bar4_that_takes_up_the_line
```

no 3 ` \` in exchange of `(` and `)`.

- Aesthetically more pleasing, but that's subjective.

The fact that `isort` picks up configuration from `.editorconfig` is not ideal, but such is our lot.