### PR TITLE
cookiecutter: convert ' ' to '_' in config_prefix

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,5 +12,5 @@
     "superproject": "Invenio",
     "transifex_project": "{{ cookiecutter.project_shortname }}",
     "extension_class": "{{ cookiecutter.project_name | replace('-', '') | replace(' ', '') }}",
-    "config_prefix": "{{ cookiecutter.project_name | replace('Invenio-', '') | replace('-', '_') | upper }}"
+    "config_prefix": "{{ cookiecutter.project_name | replace('Invenio-', '') | replace(' ', '_') | replace('-', '_') | upper }}"
 }


### PR DESCRIPTION
Fix bug if project name contains spaces.