### PR TITLE
modifications from sharpen the saw sprint

### DIFF
--- a/{{ cookiecutter.project_shortname }}/.github/workflows/pypi-release.yml
+++ b/{{ cookiecutter.project_shortname }}/.github/workflows/pypi-release.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+      - name: Build package
+        run: |
+          python setup.py compile_catalog sdist bdist_wheel
+      - name: pypi-publish
+        uses: pypa/gh-action-pypi-publish@v1.3.1
+        with:
+          user: __token__
+          {% raw %}
+          password: ${{ secrets.pypi_token }}
+          {% endraw %}

--- a/{{ cookiecutter.project_shortname }}/.travis.yml
+++ b/{{ cookiecutter.project_shortname }}/.travis.yml
@@ -1,4 +1,10 @@
 {% include 'misc/header.py' %}
+
+# blocklist
+branches:
+  except:
+  - /^v\d+\.\d+(\.\d+)?(\S*)?$/
+
 notifications:
   email: false
 
@@ -17,7 +23,7 @@ cache:
 
 env:
   - REQUIREMENTS=lowest
-  - REQUIREMENTS=release DEPLOY=true
+  - REQUIREMENTS=release
   - REQUIREMENTS=devel
 
 python:
@@ -42,15 +48,3 @@ script:
 
 after_success:
   - coveralls
-
-deploy:
-  provider: pypi
-  user: inveniosoftware
-  password:
-    secure: TODO:PYPISECUREHASH
-  distributions: "compile_catalog sdist bdist_wheel"
-  on:
-    tags: true
-    python: "3.8"
-    repo: {{ cookiecutter.github_repo }}
-    condition: $DEPLOY = true

--- a/{{ cookiecutter.project_shortname }}/MANIFEST.in
+++ b/{{ cookiecutter.project_shortname }}/MANIFEST.in
@@ -11,4 +11,5 @@ include .dockerignore
 include .editorconfig
 include .tx/config
 prune docs/_build
+recursive-include .github/workflows *.yml
 recursive-include {{ cookiecutter.package_name }}/translations *.po *.pot *.mo

--- a/{{ cookiecutter.project_shortname }}/pytest.ini
+++ b/{{ cookiecutter.project_shortname }}/pytest.ini
@@ -3,3 +3,4 @@
 pep8ignore = docs/conf.py ALL
 addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov={{ cookiecutter.package_name }} --cov-report=term-missing
 testpaths = docs tests {{ cookiecutter.package_name }}
+filterwarnings = ignore::pytest.PytestDeprecationWarning

--- a/{{ cookiecutter.project_shortname }}/run-tests.sh
+++ b/{{ cookiecutter.project_shortname }}/run-tests.sh
@@ -5,4 +5,4 @@ pydocstyle {{ cookiecutter.package_name }} tests docs && \
 isort {{ cookiecutter.package_name }} tests --check-only --diff && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test
+python -m pytest

--- a/{{ cookiecutter.project_shortname }}/run-tests.sh
+++ b/{{ cookiecutter.project_shortname }}/run-tests.sh
@@ -4,11 +4,12 @@
 # TODO: Pass the services required by your module to the
 # docker-services-cli e.g. `docker-services-cli up es postgresql redis`
 docker-services-cli up
-pydocstyle {{ cookiecutter.package_name }} tests docs && \
-isort {{ cookiecutter.package_name }} tests --check-only --diff && \
-check-manifest --ignore ".travis-*" && \
-sphinx-build -qnNW docs docs/_build/html && \
+python -m pydocstyle {{ cookiecutter.package_name }} tests docs && \
+python -m isort {{ cookiecutter.package_name }} tests --check-only --diff && \
+python -m check_manifest --ignore ".travis-*" && \
+python -m sphinx.cmd.build -qnNW docs docs/_build/html && \
 python -m pytest
+python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest
 tests_exit_code=$?
 docker-services-cli down
 exit "$tests_exit_code"

--- a/{{ cookiecutter.project_shortname }}/run-tests.sh
+++ b/{{ cookiecutter.project_shortname }}/run-tests.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env sh
 {% include 'misc/header.py' %}
 
+# TODO: Pass the services required by your module to the
+# docker-services-cli e.g. `docker-services-cli up es postgresql redis`
+docker-services-cli up
 pydocstyle {{ cookiecutter.package_name }} tests docs && \
 isort {{ cookiecutter.package_name }} tests --check-only --diff && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python -m pytest
+tests_exit_code=$?
+docker-services-cli down
+exit "$tests_exit_code"

--- a/{{ cookiecutter.project_shortname }}/run-tests.sh
+++ b/{{ cookiecutter.project_shortname }}/run-tests.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 {% include 'misc/header.py' %}
+
 pydocstyle {{ cookiecutter.package_name }} tests docs && \
-isort -rc -c -df && \
+isort {{ cookiecutter.package_name }} tests --check-only --diff && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test

--- a/{{ cookiecutter.project_shortname }}/setup.cfg
+++ b/{{ cookiecutter.project_shortname }}/setup.cfg
@@ -1,6 +1,4 @@
 {% include 'misc/header.py' %}
-[aliases]
-test = pytest
 
 [build_sphinx]
 source-dir = docs/

--- a/{{ cookiecutter.project_shortname }}/setup.py
+++ b/{{ cookiecutter.project_shortname }}/setup.py
@@ -9,13 +9,7 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'check-manifest>=0.25',
-    'coverage>=4.0',
-    'isort>=4.3.3',
-    'pydocstyle>=2.0.0',
-    'pytest-cov>=2.5.1',
-    'pytest-pep8>=1.0.6',
-    'pytest-invenio>=1.2.1',
+    'pytest-invenio>=1.3.2',
 ]
 
 extras_require = {


### PR DESCRIPTION
- Migrate to Pytest-Invenio centrally managed test dependencies
- Release packages using GH actions

**Questions**

@diegodelemos @lnielsen @inveniosoftware/architects 
This cookiecutter assumes no services are needed (e.g. it does not install `invenio-db`, `invenio-serach` or similar.) However, the `docker-services-cli` needs some input to boot up (e.g. `docker-services-cli up es mysql`). What should go to the `run-tests.sh` script?
- Specify nothing: up of *all* the services.
- Make cookiecutter aware of services: e.g. get user input for ES, DBs etc, and add them to `setup.py` and `run-tests.sh`.

Closes https://github.com/inveniosoftware/invenio/issues/4036