### PR TITLE
Replaced deprecated flask_babelex with flask_babel

### DIFF
--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/ext.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/ext.py
@@ -1,7 +1,7 @@
 {% include 'misc/header.py' %}
 """{{ cookiecutter.description }}."""
 
-from flask_babel import gettext as _
+from invenio_i18n import gettext as _
 
 from . import config
 

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/ext.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/ext.py
@@ -1,7 +1,7 @@
 {% include 'misc/header.py' %}
 """{{ cookiecutter.description }}."""
 
-from flask_babelex import gettext as _
+from flask_babel import gettext as _
 
 from . import config
 

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/views.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/views.py
@@ -5,7 +5,7 @@
 # the templates and static folders as well as the test case.
 
 from flask import Blueprint, render_template
-from flask_babelex import gettext as _
+from flask_babel import gettext as _
 
 blueprint = Blueprint(
     "{{ cookiecutter.package_name }}",

--- a/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/views.py
+++ b/{{ cookiecutter.project_shortname }}/{{ cookiecutter.package_name }}/views.py
@@ -5,7 +5,7 @@
 # the templates and static folders as well as the test case.
 
 from flask import Blueprint, render_template
-from flask_babel import gettext as _
+from invenio_i18n import gettext as _
 
 blueprint = Blueprint(
     "{{ cookiecutter.package_name }}",


### PR DESCRIPTION
### Description

[Issue 150](https://github.com/inveniosoftware/cookiecutter-invenio-module/issues/150) describes deprecated imports of flask_babelex in the cookiecutter template. This pull request replaces them with the currently supported flask_babel.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
